### PR TITLE
Equal alignment for location/date and supervisors

### DIFF
--- a/WeSTthesis.cls
+++ b/WeSTthesis.cls
@@ -256,12 +256,12 @@
         Zweitgutachter: & \secondreviewer\\
         {} & \secondreviewerinfo\\[2cm]
       \fi
+      \ifdate
+        Koblenz, \today &
+      \else
+        Koblenz, im\monthword\ \the\year &
+      \fi
     \end{tabular}\\
-    \ifdate
-      Koblenz, \today
-    \else
-      Koblenz, im\monthword\ \the\year
-    \fi
   \end{titlepage}
   \iftwoside
     \thispagestyle{empty}

--- a/example.tex
+++ b/example.tex
@@ -13,11 +13,11 @@
 
 \author{Erika Mustermann}
 
-\title{Die Verbreitung des Begriffes \glqq Mustermann\grqq\ im Zusammenhang mit Beispieltexten}
+\title{Die Verbreitung des Begriffes \glqq{}Mustermann\grqq{} im Zusammenhang mit Beispieltexten}
 
 \degreecourse{Informatik}
 
-\firstreviewer{Prof. Dr. Steffen Staab}
+\firstreviewer{Prof.\ Dr.\ Steffen Staab}
 \firstreviewerinfo{Institute for Web Science and Technologies}
 
 \secondreviewer{Max Mustermann}
@@ -34,7 +34,7 @@
 
 \tableofcontents
 
-\varclearpage
+\varclearpage%
 
 % list of figures
 % \listoffigures


### PR DESCRIPTION
- Make both of them equally left-aligned by moving location/date into the `tabular` environment.
- Also, fix LaTeX warnings in `example.tex`.
